### PR TITLE
Detailed Metrics [Draft]

### DIFF
--- a/src/config/config_impl.go
+++ b/src/config/config_impl.go
@@ -60,8 +60,8 @@ var validKeys = map[string]bool{
 //todo : ret.TotalHits = statsScope.NewCounter(key+ application + endpoint + tenant + ".total_hits")
 func newRateLimitStats(statsScope stats.Scope, key string) RateLimitStats {
 	ret := RateLimitStats{}
-	ret.TotalHits = statsScope.NewCounter(key + ".test"+ ".total_hits")
-	ret.OverLimit = statsScope.NewCounter(key + ".test1"+ ".test2" + ".over_limit")
+	ret.TotalHits = statsScope.NewCounter(key + ".test" + ".total_hits")
+	ret.OverLimit = statsScope.NewCounter(key + ".test1" + ".test2" + ".over_limit")
 	ret.NearLimit = statsScope.NewCounter(key + ".test3" + ".test2" + ".test1" + ".near_limit")
 	ret.OverLimitWithLocalCache = statsScope.NewCounter(key + ".over_limit_with_local_cache")
 	return ret

--- a/src/config/config_impl.go
+++ b/src/config/config_impl.go
@@ -78,9 +78,9 @@ func NewRateLimit(
 
 	return &RateLimit{FullKey: key, Stats: newRateLimitStats(scope, key), Limit: &pb.RateLimitResponse_RateLimit{RequestsPerUnit: requestsPerUnit, Unit: unit}}
 }
-
+//todo: consider adding a prepend to the key as to not count precise metrics twice.
 func (this *rateLimitConfigImpl) GetDescriptorStat(domain string, descriptor *pb_struct.RateLimitDescriptor) *RateLimitStats {
-	key := domain + "." + this.descriptorToKey(descriptor)
+	key := domain + "." + this.descriptorToKey(descriptor) + "DM"
 	ret := newRateLimitStats(this.statsScope, key)
 	return &ret
 }

--- a/src/config/config_impl.go
+++ b/src/config/config_impl.go
@@ -60,6 +60,7 @@ var validKeys = map[string]bool{
 //todo : ret.TotalHits = statsScope.NewCounter(key+ application + endpoint + tenant + ".total_hits")
 func newRateLimitStats(statsScope stats.Scope, key string) RateLimitStats {
 	ret := RateLimitStats{}
+	logger.Debugf("outputing test stats %s", key)
 	ret.TotalHits = statsScope.NewCounter(key + ".test" + ".total_hits")
 	ret.OverLimit = statsScope.NewCounter(key + ".test1" + ".test2" + ".over_limit")
 	ret.NearLimit = statsScope.NewCounter(key + ".test3" + ".test2" + ".test1" + ".near_limit")

--- a/src/config/config_impl.go
+++ b/src/config/config_impl.go
@@ -60,9 +60,9 @@ var validKeys = map[string]bool{
 //todo : ret.TotalHits = statsScope.NewCounter(key+ application + endpoint + tenant + ".total_hits")
 func newRateLimitStats(statsScope stats.Scope, key string) RateLimitStats {
 	ret := RateLimitStats{}
-	ret.TotalHits = statsScope.NewCounter(key + ".total_hits")
-	ret.OverLimit = statsScope.NewCounter(key + ".over_limit")
-	ret.NearLimit = statsScope.NewCounter(key + ".near_limit")
+	ret.TotalHits = statsScope.NewCounter(key + ".test"+ ".total_hits")
+	ret.OverLimit = statsScope.NewCounter(key + ".test1"+ ".test2" + ".over_limit")
+	ret.NearLimit = statsScope.NewCounter(key + ".test3" + ".test2" + ".test1" + ".near_limit")
 	ret.OverLimitWithLocalCache = statsScope.NewCounter(key + ".over_limit_with_local_cache")
 	return ret
 }

--- a/src/config/config_impl.go
+++ b/src/config/config_impl.go
@@ -61,9 +61,9 @@ var validKeys = map[string]bool{
 func newRateLimitStats(statsScope stats.Scope, key string) RateLimitStats {
 	ret := RateLimitStats{}
 	logger.Debugf("outputing test stats %s", key)
-	ret.TotalHits = statsScope.NewCounter(key + ".test" + ".total_hits")
-	ret.OverLimit = statsScope.NewCounter(key + ".test1" + ".test2" + ".over_limit")
-	ret.NearLimit = statsScope.NewCounter(key + ".test3" + ".test2" + ".test1" + ".near_limit")
+	ret.TotalHits = statsScope.NewCounter(key + ".total_hits")
+	ret.OverLimit = statsScope.NewCounter(key + ".over_limit")
+	ret.NearLimit = statsScope.NewCounter(key + ".near_limit")
 	ret.OverLimitWithLocalCache = statsScope.NewCounter(key + ".over_limit_with_local_cache")
 	return ret
 }

--- a/src/config/config_impl.go
+++ b/src/config/config_impl.go
@@ -57,6 +57,7 @@ var validKeys = map[string]bool{
 // @param statsScope supplies the owning scope.
 // @param key supplies the fully resolved key name of the entry.
 // @return new stats.
+//todo : ret.TotalHits = statsScope.NewCounter(key+ application + endpoint + tenant + ".total_hits")
 func newRateLimitStats(statsScope stats.Scope, key string) RateLimitStats {
 	ret := RateLimitStats{}
 	ret.TotalHits = statsScope.NewCounter(key + ".total_hits")

--- a/src/config/config_impl.go
+++ b/src/config/config_impl.go
@@ -57,7 +57,6 @@ var validKeys = map[string]bool{
 // @param statsScope supplies the owning scope.
 // @param key supplies the fully resolved key name of the entry.
 // @return new stats.
-//todo : ret.TotalHits = statsScope.NewCounter(key+ application + endpoint + tenant + ".total_hits")
 func newRateLimitStats(statsScope stats.Scope, key string) RateLimitStats {
 	ret := RateLimitStats{}
 	logger.Debugf("outputing test stats %s", key)
@@ -78,6 +77,12 @@ func NewRateLimit(
 	requestsPerUnit uint32, unit pb.RateLimitResponse_RateLimit_Unit, key string, scope stats.Scope) *RateLimit {
 
 	return &RateLimit{FullKey: key, Stats: newRateLimitStats(scope, key), Limit: &pb.RateLimitResponse_RateLimit{RequestsPerUnit: requestsPerUnit, Unit: unit}}
+}
+
+func (this *rateLimitConfigImpl) GetDescriptorStat(domain string, descriptor *pb_struct.RateLimitDescriptor) *RateLimitStats {
+	key := domain + "." + this.descriptorToKey(descriptor)
+	ret := newRateLimitStats(this.statsScope, key)
+	return &ret
 }
 
 // Dump an individual descriptor for debugging purposes.

--- a/src/limiter/cache.go
+++ b/src/limiter/cache.go
@@ -31,8 +31,5 @@ type RateLimitCache interface {
 	//               list must be same as the length of the descriptors list.
 	// @return a list of DescriptorStatuses which corresponds to each passed in descriptor/limit pair.
 	// 				 Throws RedisError if there was any error talking to the cache.
-	DoLimit(
-		ctx context.Context,
-		request *pb.RateLimitRequest,
-		limits []*config.RateLimit) []*pb.RateLimitResponse_DescriptorStatus
+	DoLimit(ctx context.Context, request *pb.RateLimitRequest, limits []*config.RateLimit, rlConfig config.RateLimitConfig) []*pb.RateLimitResponse_DescriptorStatus
 }

--- a/src/redis/cache_impl.go
+++ b/src/redis/cache_impl.go
@@ -62,7 +62,7 @@ func (this *rateLimitCacheImpl) DoLimit(
 	for i := 0; i < len(request.Descriptors); i++ {
 		cacheKeys[i] = this.cacheKeyGenerator.GenerateCacheKey(
 			request.Domain, request.Descriptors[i], limits[i], now)
-
+		logger.Warnf("Cache Key: %s", cacheKeys[i].Key)
 		// Increase statistics for limits hit by their respective requests.
 		if limits[i] != nil {
 			limits[i].Stats.TotalHits.Add(uint64(hitsAddend))

--- a/src/redis/cache_impl.go
+++ b/src/redis/cache_impl.go
@@ -46,7 +46,9 @@ func pipelineAppend(client Client, pipeline *Pipeline, key string, hitsAddend ui
 func (this *rateLimitCacheImpl) DoLimit(
 	ctx context.Context,
 	request *pb.RateLimitRequest,
-	limits []*config.RateLimit) []*pb.RateLimitResponse_DescriptorStatus {
+	limits []*config.RateLimit,
+	rlConfig config.RateLimitConfig,
+) []*pb.RateLimitResponse_DescriptorStatus {
 
 	logger.Debugf("starting cache lookup")
 

--- a/src/service/ratelimit.go
+++ b/src/service/ratelimit.go
@@ -145,7 +145,7 @@ func (this *service) shouldRateLimitWorker(
 		limitsToCheck[i] = snappedConfig.GetLimit(ctx, request.Domain, descriptor)
 	}
 
-	responseDescriptorStatuses := this.cache.DoLimit(ctx, request, limitsToCheck)
+	responseDescriptorStatuses := this.cache.DoLimit(ctx, request, limitsToCheck, snappedConfig)
 	logger.Warnf("LL %d DL %d", len(limitsToCheck), len(responseDescriptorStatuses))
 	assert.Assert(len(limitsToCheck) == len(responseDescriptorStatuses))
 

--- a/test/mocks/limiter/limiter.go
+++ b/test/mocks/limiter/limiter.go
@@ -9,6 +9,7 @@ import (
 	envoy_service_ratelimit_v3 "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v3"
 	config "github.com/envoyproxy/ratelimit/src/config"
 	gomock "github.com/golang/mock/gomock"
+	context2 "golang.org/x/net/context"
 	reflect "reflect"
 )
 
@@ -36,7 +37,7 @@ func (m *MockRateLimitCache) EXPECT() *MockRateLimitCacheMockRecorder {
 }
 
 // DoLimit mocks base method
-func (m *MockRateLimitCache) DoLimit(arg0 context.Context, arg1 *envoy_service_ratelimit_v3.RateLimitRequest, arg2 []*config.RateLimit) []*envoy_service_ratelimit_v3.RateLimitResponse_DescriptorStatus {
+func (m *MockRateLimitCache) DoLimit(ctx context2.Context, request *envoy_service_ratelimit_v3.RateLimitRequest, limits []*config.RateLimit, snappedConfig config.RateLimitConfig) []*envoy_service_ratelimit_v3.RateLimitResponse_DescriptorStatus {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DoLimit", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]*envoy_service_ratelimit_v3.RateLimitResponse_DescriptorStatus)

--- a/test/redis/bench_test.go
+++ b/test/redis/bench_test.go
@@ -59,7 +59,7 @@ func BenchmarkParallelDoLimit(b *testing.B) {
 			b.ResetTimer()
 
 			do(b, func() error {
-				cache.DoLimit(context.Background(), request, limits)
+				cache.DoLimit(context.Background(), request, limits, nil)
 				return nil
 			})
 		}

--- a/test/redis/cache_impl_test.go
+++ b/test/redis/cache_impl_test.go
@@ -66,7 +66,7 @@ func testRedis(usePerSecondRedis bool) func(*testing.T) {
 
 		assert.Equal(
 			[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OK, CurrentLimit: limits[0].Limit, LimitRemaining: 5, DurationUntilReset: redis.CalculateReset(limits[0].Limit, timeSource)}},
-			cache.DoLimit(nil, request, limits))
+			cache.DoLimit(nil, request, limits, nil))
 		assert.Equal(uint64(1), limits[0].Stats.TotalHits.Value())
 		assert.Equal(uint64(0), limits[0].Stats.OverLimit.Value())
 		assert.Equal(uint64(0), limits[0].Stats.NearLimit.Value())
@@ -90,7 +90,7 @@ func testRedis(usePerSecondRedis bool) func(*testing.T) {
 		assert.Equal(
 			[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OK, CurrentLimit: nil, LimitRemaining: 0},
 				{Code: pb.RateLimitResponse_OVER_LIMIT, CurrentLimit: limits[1].Limit, LimitRemaining: 0, DurationUntilReset: redis.CalculateReset(limits[1].Limit, timeSource)}},
-			cache.DoLimit(nil, request, limits))
+			cache.DoLimit(nil, request, limits, nil))
 		assert.Equal(uint64(1), limits[1].Stats.TotalHits.Value())
 		assert.Equal(uint64(1), limits[1].Stats.OverLimit.Value())
 		assert.Equal(uint64(0), limits[1].Stats.NearLimit.Value())
@@ -118,7 +118,7 @@ func testRedis(usePerSecondRedis bool) func(*testing.T) {
 			[]*pb.RateLimitResponse_DescriptorStatus{
 				{Code: pb.RateLimitResponse_OVER_LIMIT, CurrentLimit: limits[0].Limit, LimitRemaining: 0, DurationUntilReset: redis.CalculateReset(limits[0].Limit, timeSource)},
 				{Code: pb.RateLimitResponse_OVER_LIMIT, CurrentLimit: limits[1].Limit, LimitRemaining: 0, DurationUntilReset: redis.CalculateReset(limits[1].Limit, timeSource)}},
-			cache.DoLimit(nil, request, limits))
+			cache.DoLimit(nil, request, limits, nil))
 		assert.Equal(uint64(1), limits[0].Stats.TotalHits.Value())
 		assert.Equal(uint64(1), limits[0].Stats.OverLimit.Value())
 		assert.Equal(uint64(0), limits[0].Stats.NearLimit.Value())
@@ -192,7 +192,7 @@ func TestOverLimitWithLocalCache(t *testing.T) {
 	assert.Equal(
 		[]*pb.RateLimitResponse_DescriptorStatus{
 			{Code: pb.RateLimitResponse_OK, CurrentLimit: limits[0].Limit, LimitRemaining: 4, DurationUntilReset: redis.CalculateReset(limits[0].Limit, timeSource)}},
-		cache.DoLimit(nil, request, limits))
+		cache.DoLimit(nil, request, limits, nil))
 	assert.Equal(uint64(1), limits[0].Stats.TotalHits.Value())
 	assert.Equal(uint64(0), limits[0].Stats.OverLimit.Value())
 	assert.Equal(uint64(0), limits[0].Stats.OverLimitWithLocalCache.Value())
@@ -211,7 +211,7 @@ func TestOverLimitWithLocalCache(t *testing.T) {
 	assert.Equal(
 		[]*pb.RateLimitResponse_DescriptorStatus{
 			{Code: pb.RateLimitResponse_OK, CurrentLimit: limits[0].Limit, LimitRemaining: 2, DurationUntilReset: redis.CalculateReset(limits[0].Limit, timeSource)}},
-		cache.DoLimit(nil, request, limits))
+		cache.DoLimit(nil, request, limits, nil))
 	assert.Equal(uint64(2), limits[0].Stats.TotalHits.Value())
 	assert.Equal(uint64(0), limits[0].Stats.OverLimit.Value())
 	assert.Equal(uint64(0), limits[0].Stats.OverLimitWithLocalCache.Value())
@@ -230,7 +230,7 @@ func TestOverLimitWithLocalCache(t *testing.T) {
 	assert.Equal(
 		[]*pb.RateLimitResponse_DescriptorStatus{
 			{Code: pb.RateLimitResponse_OVER_LIMIT, CurrentLimit: limits[0].Limit, LimitRemaining: 0, DurationUntilReset: redis.CalculateReset(limits[0].Limit, timeSource)}},
-		cache.DoLimit(nil, request, limits))
+		cache.DoLimit(nil, request, limits, nil))
 	assert.Equal(uint64(3), limits[0].Stats.TotalHits.Value())
 	assert.Equal(uint64(1), limits[0].Stats.OverLimit.Value())
 	assert.Equal(uint64(0), limits[0].Stats.OverLimitWithLocalCache.Value())
@@ -247,7 +247,7 @@ func TestOverLimitWithLocalCache(t *testing.T) {
 	assert.Equal(
 		[]*pb.RateLimitResponse_DescriptorStatus{
 			{Code: pb.RateLimitResponse_OVER_LIMIT, CurrentLimit: limits[0].Limit, LimitRemaining: 0, DurationUntilReset: redis.CalculateReset(limits[0].Limit, timeSource)}},
-		cache.DoLimit(nil, request, limits))
+		cache.DoLimit(nil, request, limits, nil))
 	assert.Equal(uint64(4), limits[0].Stats.TotalHits.Value())
 	assert.Equal(uint64(2), limits[0].Stats.OverLimit.Value())
 	assert.Equal(uint64(1), limits[0].Stats.OverLimitWithLocalCache.Value())
@@ -282,7 +282,7 @@ func TestNearLimit(t *testing.T) {
 	assert.Equal(
 		[]*pb.RateLimitResponse_DescriptorStatus{
 			{Code: pb.RateLimitResponse_OK, CurrentLimit: limits[0].Limit, LimitRemaining: 4, DurationUntilReset: redis.CalculateReset(limits[0].Limit, timeSource)}},
-		cache.DoLimit(nil, request, limits))
+		cache.DoLimit(nil, request, limits, nil))
 	assert.Equal(uint64(1), limits[0].Stats.TotalHits.Value())
 	assert.Equal(uint64(0), limits[0].Stats.OverLimit.Value())
 	assert.Equal(uint64(0), limits[0].Stats.NearLimit.Value())
@@ -297,7 +297,7 @@ func TestNearLimit(t *testing.T) {
 	assert.Equal(
 		[]*pb.RateLimitResponse_DescriptorStatus{
 			{Code: pb.RateLimitResponse_OK, CurrentLimit: limits[0].Limit, LimitRemaining: 2, DurationUntilReset: redis.CalculateReset(limits[0].Limit, timeSource)}},
-		cache.DoLimit(nil, request, limits))
+		cache.DoLimit(nil, request, limits, nil))
 	assert.Equal(uint64(2), limits[0].Stats.TotalHits.Value())
 	assert.Equal(uint64(0), limits[0].Stats.OverLimit.Value())
 	assert.Equal(uint64(1), limits[0].Stats.NearLimit.Value())
@@ -313,7 +313,7 @@ func TestNearLimit(t *testing.T) {
 	assert.Equal(
 		[]*pb.RateLimitResponse_DescriptorStatus{
 			{Code: pb.RateLimitResponse_OVER_LIMIT, CurrentLimit: limits[0].Limit, LimitRemaining: 0, DurationUntilReset: redis.CalculateReset(limits[0].Limit, timeSource)}},
-		cache.DoLimit(nil, request, limits))
+		cache.DoLimit(nil, request, limits, nil))
 	assert.Equal(uint64(3), limits[0].Stats.TotalHits.Value())
 	assert.Equal(uint64(1), limits[0].Stats.OverLimit.Value())
 	assert.Equal(uint64(1), limits[0].Stats.NearLimit.Value())
@@ -330,7 +330,7 @@ func TestNearLimit(t *testing.T) {
 
 	assert.Equal(
 		[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OK, CurrentLimit: limits[0].Limit, LimitRemaining: 15, DurationUntilReset: redis.CalculateReset(limits[0].Limit, timeSource)}},
-		cache.DoLimit(nil, request, limits))
+		cache.DoLimit(nil, request, limits, nil))
 	assert.Equal(uint64(3), limits[0].Stats.TotalHits.Value())
 	assert.Equal(uint64(0), limits[0].Stats.OverLimit.Value())
 	assert.Equal(uint64(0), limits[0].Stats.NearLimit.Value())
@@ -346,7 +346,7 @@ func TestNearLimit(t *testing.T) {
 
 	assert.Equal(
 		[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OK, CurrentLimit: limits[0].Limit, LimitRemaining: 1, DurationUntilReset: redis.CalculateReset(limits[0].Limit, timeSource)}},
-		cache.DoLimit(nil, request, limits))
+		cache.DoLimit(nil, request, limits, nil))
 	assert.Equal(uint64(2), limits[0].Stats.TotalHits.Value())
 	assert.Equal(uint64(0), limits[0].Stats.OverLimit.Value())
 	assert.Equal(uint64(1), limits[0].Stats.NearLimit.Value())
@@ -362,7 +362,7 @@ func TestNearLimit(t *testing.T) {
 
 	assert.Equal(
 		[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OK, CurrentLimit: limits[0].Limit, LimitRemaining: 1, DurationUntilReset: redis.CalculateReset(limits[0].Limit, timeSource)}},
-		cache.DoLimit(nil, request, limits))
+		cache.DoLimit(nil, request, limits, nil))
 	assert.Equal(uint64(3), limits[0].Stats.TotalHits.Value())
 	assert.Equal(uint64(0), limits[0].Stats.OverLimit.Value())
 	assert.Equal(uint64(3), limits[0].Stats.NearLimit.Value())
@@ -378,7 +378,7 @@ func TestNearLimit(t *testing.T) {
 
 	assert.Equal(
 		[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OVER_LIMIT, CurrentLimit: limits[0].Limit, LimitRemaining: 0, DurationUntilReset: redis.CalculateReset(limits[0].Limit, timeSource)}},
-		cache.DoLimit(nil, request, limits))
+		cache.DoLimit(nil, request, limits, nil))
 	assert.Equal(uint64(3), limits[0].Stats.TotalHits.Value())
 	assert.Equal(uint64(2), limits[0].Stats.OverLimit.Value())
 	assert.Equal(uint64(1), limits[0].Stats.NearLimit.Value())
@@ -394,7 +394,7 @@ func TestNearLimit(t *testing.T) {
 
 	assert.Equal(
 		[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OVER_LIMIT, CurrentLimit: limits[0].Limit, LimitRemaining: 0, DurationUntilReset: redis.CalculateReset(limits[0].Limit, timeSource)}},
-		cache.DoLimit(nil, request, limits))
+		cache.DoLimit(nil, request, limits, nil))
 	assert.Equal(uint64(7), limits[0].Stats.TotalHits.Value())
 	assert.Equal(uint64(2), limits[0].Stats.OverLimit.Value())
 	assert.Equal(uint64(4), limits[0].Stats.NearLimit.Value())
@@ -410,7 +410,7 @@ func TestNearLimit(t *testing.T) {
 
 	assert.Equal(
 		[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OVER_LIMIT, CurrentLimit: limits[0].Limit, LimitRemaining: 0, DurationUntilReset: redis.CalculateReset(limits[0].Limit, timeSource)}},
-		cache.DoLimit(nil, request, limits))
+		cache.DoLimit(nil, request, limits, nil))
 	assert.Equal(uint64(3), limits[0].Stats.TotalHits.Value())
 	assert.Equal(uint64(3), limits[0].Stats.OverLimit.Value())
 	assert.Equal(uint64(0), limits[0].Stats.NearLimit.Value())
@@ -438,7 +438,7 @@ func TestRedisWithJitter(t *testing.T) {
 
 	assert.Equal(
 		[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OK, CurrentLimit: limits[0].Limit, LimitRemaining: 5, DurationUntilReset: redis.CalculateReset(limits[0].Limit, timeSource)}},
-		cache.DoLimit(nil, request, limits))
+		cache.DoLimit(nil, request, limits, nil))
 	assert.Equal(uint64(1), limits[0].Stats.TotalHits.Value())
 	assert.Equal(uint64(0), limits[0].Stats.OverLimit.Value())
 	assert.Equal(uint64(0), limits[0].Stats.NearLimit.Value())


### PR DESCRIPTION
Allow opt-in detailed metrics mode, for use-cases where additional metric granularity is required.

Additional details: https://github.com/envoyproxy/ratelimit/issues/181